### PR TITLE
fix: snap to grid (bottom)

### DIFF
--- a/packages/react-moveable/src/react-moveable/ables/snappable/snap.ts
+++ b/packages/react-moveable/src/react-moveable/ables/snappable/snap.ts
@@ -408,7 +408,7 @@ export function getGridGuidelines(
     const guidelines: SnapGuideline[] = [];
 
     if (snapGridHeight) {
-        for (let pos = 0; pos < containerHeight; pos += snapGridHeight) {
+        for (let pos = 0; pos <= containerHeight; pos += snapGridHeight) {
             guidelines.push({
                 type: "horizontal",
                 pos: [0, throttle(pos - clientTop, 0.1)],


### PR DESCRIPTION
fix snap to the end of the grid vertically

![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/13840865/122326337-fe565900-cee0-11eb-8518-4464bc3629ca.gif)
